### PR TITLE
fix: small fix to improve error response object

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -28,7 +28,7 @@ class AifiError extends Error {
       case 'E_UNAUTHORIZED':
         return new AifiAuthenticationError(rawAifiError);
       default:
-        return new Error('Generic', 'Unknown Error');
+        return new AifiError(rawAifiError);
     }
   }
 }


### PR DESCRIPTION
Small adjustment to error response object

```javascript
  static generate(rawAifiError) {
    switch (rawAifiError.type) {
      case 'invalid_request_error':
        return new AifiInvalidRequestError(rawAifiError);
      case 'api_error':
        return new AifiAPIError(rawAifiError);
      case 'E_UNAUTHORIZED':
        return new AifiAuthenticationError(rawAifiError);
      default:
        return new AifiError(rawAifiError); // <------- updated
    }
  }
}
```