### PR TITLE
hotfix/customer-contest-type-errors

### DIFF
--- a/types/Customer/Contests.d.ts
+++ b/types/Customer/Contests.d.ts
@@ -13,7 +13,7 @@ declare module 'aifi' {
         message: string;
 
         /**
-         * Items to be contested array
+         * Array list of items/products to be contested
          */
         items: Aifi.Models.ContestItem[];
       }


### PR DESCRIPTION
Updated customer contest types to fix order id type and comments

issue:

orderId was typed string

Fix:

orderId typed as number

<img width="437" alt="Screenshot 2022-04-22 at 13 04 26" src="https://user-images.githubusercontent.com/65465380/164710858-c794148e-1d51-4921-b53d-1fd78d324ff9.png">

