### PR TITLE
fix: aifi.admin.stores.updateGondolaPlanogram returns a plain text response

### DIFF
--- a/lib/net/NodeHttpClient.js
+++ b/lib/net/NodeHttpClient.js
@@ -105,6 +105,11 @@ class NodeHttpClientResponse extends HttpClientResponse {
       });
       this._res.once('end', () => {
         try {
+          const contentType = this._res.headers['content-type'];
+          if (contentType === 'text/plain; charset=utf-8') {
+            response = JSON.stringify({response});
+          }
+
           resolve(JSON.parse(response));
         } catch (e) {
           reject(e);


### PR DESCRIPTION
Example. Calling

``` 
aifi.admin.stores
  .updateGondolaPlanogram('1', '1', {
    shelfIndex: 1,
    bins: [
      {
        size: 0.28,
        productId: 1,
      },
    ],
    sizeType: 'meters',
  })
  .then((res) => console.log(res))
```

Returns a response with headers text/plain and content 'OK'

This PR ensures any plain text responses are correctly formatted as JSON so they can be passed down properly through the SDK